### PR TITLE
Install setuptools-scm to generate correct version string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,18 @@ source:
   sha256: f178e336412eaefdb74172b280095cd9bd497bfeb235c1b1c2b0965c21aa1af0
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - ome_zarr = ome_zarr.cli:main
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
     - python >3.10
-    - setuptools
+    - setuptools >=64
+    - setuptools-scm >=8.0
   run:
     - aiohttp <4
     - dask-core
@@ -38,6 +39,7 @@ test:
   imports:
     - ome_zarr
   commands:
+    - python -c "import importlib.metadata; print(importlib.metadata.version('ome_zarr'))" | grep -q {{ version }}
     - pip check
     - ome_zarr --help
   requires:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Fixes https://github.com/conda-forge/ome-zarr-feedstock/issues/24
Fixes https://github.com/ome/ome-zarr-py/issues/448
(due to permission issues, I doubt these will auto-close)

* ome-zarr-py migrated to setuptools-scm (https://github.com/ome/ome-zarr-py/pull/346)
* But setuptools-scm was not installed in the feedstock builds for 0.10.3 (https://github.com/conda-forge/ome-zarr-feedstock/pull/22) or 0.11.1 (https://github.com/conda-forge/ome-zarr-feedstock/pull/25)
* Thus the version string of the conda-forge binary is `0.0.0`, which breaks `pip check` of downstream conda-forge recipes (https://github.com/conda-forge/ome-zarr-feedstock/issues/24) and confuses end users (https://github.com/ome/ome-zarr-py/issues/448)
* This PR installs setuptools-scm and also adds a test to confirm the version string matches the recipe version
* The `SETUPTOOLS_SCM_PRETEND_VERSION` workaround is not needed in this particular case because ome-zarr-py uses the setuptools-scm feature [`version_file = "ome_zarr/_version.py"`](https://github.com/ome/ome-zarr-py/blob/v0.11.1/pyproject.toml#L78), which writes the version to the file `_version.py` and distributes this file in the source tarball uploaded to PyPI. The env var `SETUPTOOLS_SCM_PRETEND_VERSION` is only required when a package uses an even more opaque strategy of setuptools-scm