### PR TITLE
Require Python >=3.11 using CFEP-25 syntax

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,5 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+python_min:
+- '3.9'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @constantinpape @joshmoore @k-dominik
+* @constantinpape @jdblischak @joshmoore @k-dominik

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Feedstock Maintainers
 =====================
 
 * [@constantinpape](https://github.com/constantinpape/)
+* [@jdblischak](https://github.com/jdblischak/)
 * [@joshmoore](https://github.com/joshmoore/)
 * [@k-dominik](https://github.com/k-dominik/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ome-zarr" %}
 {% set version = "0.11.1" %}
-
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -20,7 +20,7 @@ build:
 requirements:
   host:
     - pip
-    - python >3.10
+    - python {{ python_min }}
     - setuptools >=64
     - setuptools-scm >=8.0
   run:
@@ -29,7 +29,7 @@ requirements:
     - distributed
     - fsspec >=0.8,!=2021.07.0,!=2023.9.0
     - numpy
-    - python >3.10
+    - python >={{ python_min }}
     - requests
     - scikit-image
     - toolz
@@ -44,7 +44,7 @@ test:
     - ome_zarr --help
   requires:
     - pip
-    - python >3.10
+    - python {{ python_min }}
 
 about:
   home: https://github.com/ome/ome-zarr-py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,3 +57,4 @@ extra:
     - constantinpape
     - joshmoore
     - k-dominik
+    - jdblischak


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

* Revert to using CFEP-25 syntax (#20, https://github.com/conda-forge/ome-zarr-feedstock/pull/26#issuecomment-2940697420)
* Require python>=3.11 (https://github.com/ome/ome-zarr-py/commit/50d40f58e612d501b7095d82a006dc5c43880fc0)
* Add myself as a maintainer
* Purposefully didn't bump build number. I don't want to upload a new binary for this minimal change

Note that this change enforces python>=3.11. The existing `>3.10` is insufficient because it allows installing 3.10.x, eg

```sh
mamba create --dry-run -n test 'python>3.10' 'python=3.10'
## + python              3.10.18  hd6af730_0_cpython  conda-forge       25MB

# whereas these fail as expected
mamba create --dry-run -n test 'python>3.10' 'python=3.9'
mamba create --dry-run -n test 'python>3.10' 'python==3.10'
```

In the future, when the minimal required Python version needs updated, you can update the jinja2 variable `python_min` at the top of `meta.yaml`.