### PR TITLE
Fix version string for zarr lower bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 834e801e9aa4b870bed3dde2dc2a3ad7f388f1a13ffa6b3d7aade90691b9de64
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - ome_zarr = ome_zarr.cli:main
@@ -33,7 +33,7 @@ requirements:
     - requests
     - scikit-image >=0.19.0
     - toolz
-    - zarr >=v3.0.0
+    - zarr >=3.0.0
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

Conda does not understand the version string "v3.0.0" and thus does not properly enforce the lower bound for ome-zarr 0.12.0+. This PR fixes the version string, and I will also submit a repodata patch to fix the existing conda 0.12.0+ binaries.

Surprisingly pip appears to be able to parse the version string "v3.0.0", but it is unclear to me why one would want to prepend the `v`. The upstream zarr version strings do not actually include this superflous `v` ([zarr release history on PyPI](https://pypi.org/project/zarr/#history)).

The code below demonstrates the problem. spatialdata has not yet migrated to zarr 3 and thus pins `zarr <3`. `pip` detects the fundamental conflict, but not conda.

```sh
mamba create -n test-ome-zarr --yes -c conda-forge python=3.11
mamba activate test-ome-zarr
pip install ome-zarr==0.12.2 spatialdata==0.5.0 zarr
## ERROR: Cannot install ome-zarr==0.12.2, spatialdata==0.5.0 and zarr because these package versions have conflicting dependencies.
##
## The conflict is caused by:
##     The user requested zarr
##     ome-zarr 0.12.2 depends on zarr>=v3.0.0
##     spatialdata 0.5.0 depends on zarr<3

mamba install --dry-run ome-zarr==0.12.2 spatialdata==0.5.0 zarr
## + ome-zarr                                0.12.2  pyhd8ed1ab_0                  conda-forge       41kB
## + spatialdata                              0.5.0  pyhd8ed1ab_0                  conda-forge      140kB
## + zarr                                    2.18.7  pyhd8ed1ab_0                  conda-forge      161kB
```

edit: note that local rerendering had no effect because the feedstock was recently rerendered in #30)